### PR TITLE
修复部分长文本更新失败的问题。需要加引号，不然会出现“no such column: device_5cdbcc54db4b4”这种情况

### DIFF
--- a/YIIFMDB/YIIFMDB/YIIParameters.m
+++ b/YIIFMDB/YIIFMDB/YIIParameters.m
@@ -70,22 +70,22 @@
     NSString *string = nil;
     switch (relationType) {
         case YIIParametersRelationTypeEqualTo:
-            string = [NSString stringWithFormat:@"%@ = %@", column, value];
+            string = [NSString stringWithFormat:@"%@ = \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeUnequalTo:
-            string = [NSString stringWithFormat:@"%@ != %@", column, value];
+            string = [NSString stringWithFormat:@"%@ != \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeGreaterThan:
-            string = [NSString stringWithFormat:@"%@ > %@", column, value];
+            string = [NSString stringWithFormat:@"%@ > \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeGreaterThanOrEqualTo:
-            string = [NSString stringWithFormat:@"%@ >= %@", column, value];
+            string = [NSString stringWithFormat:@"%@ >= \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeLessThan:
-            string = [NSString stringWithFormat:@"%@ < %@", column, value];
+            string = [NSString stringWithFormat:@"%@ < \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeLessThanOrEqualTo:
-            string = [NSString stringWithFormat:@"%@ <= %@", column, value];
+            string = [NSString stringWithFormat:@"%@ <= \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeLike:
             string = [NSString stringWithFormat:@"%@ like '%@'", column, value];
@@ -102,22 +102,22 @@
     NSString *string = nil;
     switch (relationType) {
         case YIIParametersRelationTypeEqualTo:
-            string = [NSString stringWithFormat:@"%@ = %@", column, value];
+            string = [NSString stringWithFormat:@"%@ = \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeUnequalTo:
-            string = [NSString stringWithFormat:@"%@ != %@", column, value];
+            string = [NSString stringWithFormat:@"%@ != \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeGreaterThan:
-            string = [NSString stringWithFormat:@"%@ > %@", column, value];
+            string = [NSString stringWithFormat:@"%@ > \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeGreaterThanOrEqualTo:
-            string = [NSString stringWithFormat:@"%@ >= %@", column, value];
+            string = [NSString stringWithFormat:@"%@ >= \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeLessThan:
-            string = [NSString stringWithFormat:@"%@ < %@", column, value];
+            string = [NSString stringWithFormat:@"%@ < \"%@\"", column, value];
             break;
         case YIIParametersRelationTypeLessThanOrEqualTo:
-            string = [NSString stringWithFormat:@"%@ <= %@", column, value];
+            string = [NSString stringWithFormat:@"%@ <= \"%@\"", column, value];
             break;
         default:
             break;


### PR DESCRIPTION
[演示gif](https://github.com/Spriea/ProjectInit/blob/master/%E9%94%99%E8%AF%AF%E6%BC%94%E7%A4%BA.gif)